### PR TITLE
Implements grid.js for the tables

### DIFF
--- a/assets/js/grid-init.js
+++ b/assets/js/grid-init.js
@@ -1,0 +1,30 @@
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('table.js-grid').forEach(table => {
+        const headers = Array.from(table.querySelectorAll('thead th'))
+            .map(th => th.textContent.trim());
+        const data = Array.from(table.querySelectorAll('tbody tr'))
+            .map(tr =>
+                Array.from(tr.querySelectorAll('td'))
+                    .map(td => td.innerHTML.trim())
+            );
+
+        const wrapper = document.createElement('div');
+        table.parentNode.insertBefore(wrapper, table);
+
+        const grid = new gridjs.Grid({
+            columns: headers.map(name => ({
+                name,
+                sort: !['foto', 'imagem', 'ações'].includes(name.toLowerCase()),
+                formatter: cell => gridjs.html(cell),
+            })),
+            data: data,
+            search: true,
+            pagination: { enabled: true, limit: 10 },
+            className: {
+                table: 'table table-striped table-hover'
+            }
+        });
+        grid.render(wrapper);
+        table.remove();
+    });
+});

--- a/templates/_admin/opportunity/_partials/details/inscriptions.html.twig
+++ b/templates/_admin/opportunity/_partials/details/inscriptions.html.twig
@@ -1,6 +1,6 @@
 <div class="tab-pane" id="inscriptions">
     <div class="card card-body shadow">
-        <table class="table table-hover table-striped">
+        <table class="js-grid table table-hover table-striped">
             <thead class="table-dark">
             <tr>
                 <th>{{ 'photo' | trans }}</th>

--- a/templates/_admin/opportunity/_partials/details/phases.html.twig
+++ b/templates/_admin/opportunity/_partials/details/phases.html.twig
@@ -11,7 +11,7 @@
 
 <div class="tab-pane" id="phases">
     <div class="card card-body shadow">
-        <table class="table table-hover table-striped">
+        <table class="js-grid table table-hover table-striped">
             <thead class="table-dark">
             <tr>
                 <th>{{ 'name_phases' | trans }}</th>

--- a/templates/_admin/opportunity/details.html.twig
+++ b/templates/_admin/opportunity/details.html.twig
@@ -72,3 +72,7 @@
         </div>
     </section>
 {% endblock %}
+{% block extra_javascripts %}
+    {{ parent() }}
+    <script src="{{ asset('js/grid-init.js') }}"></script>
+{% endblock %}

--- a/templates/_admin/opportunity/list.html.twig
+++ b/templates/_admin/opportunity/list.html.twig
@@ -23,13 +23,11 @@
 
                         <hr>
 
-                        <table class="table table-hover table-striped">
+                        <table class="js-grid table table-hover table-striped">
                             <thead class="table-dark">
                                 <tr>
                                     <th>{{ 'name'|trans }}</th>
                                     <th>{{ 'created_at'|trans }}</th>
-                                    <th></th>
-                                    <th></th>
                                     <th>{{ 'actions'|trans }}</th>
                                 </tr>
                             </thead>
@@ -38,8 +36,6 @@
                                 <tr>
                                     <td><a href="{{ path('admin_opportunity_get', {id: item.id}) }}">{{ item.name }}</a></td>
                                     <td>{{ item.createdAt.format('d/m/Y H:i:s') }}</td>
-                                    <td></td>
-                                    <td></td>
                                     <td>
                                         <a href="{{ path('admin_opportunity_timeline', {id: item.id}) }}" class="btn btn-outline-info btn-sm">{{ 'Timeline'|trans }}</a>
                                         <a href="{{ path('admin_opportunity_edit', {id: item.id}) }}" class="btn btn-outline-warning btn-sm">{{ 'edit'|trans }}</a>
@@ -59,4 +55,5 @@
 {% block extra_javascripts %}
     {{ parent() }}
     <script src="{{ asset('js/modal-confirm-remove.js') }}"></script>
+    <script src="{{ asset('js/grid-init.js') }}"></script>
 {% endblock %}

--- a/templates/_admin/opportunity/timeline.html.twig
+++ b/templates/_admin/opportunity/timeline.html.twig
@@ -24,13 +24,12 @@
 
                         <hr>
 
-                        <table class="table table-hover table-striped">
+                        <table class="js-grid table table-hover table-striped">
                             <thead class="table-dark">
                             <tr>
                                 <th>{{ 'title'|trans }}</th>
                                 <th>{{ 'created_at'|trans }}</th>
                                 <th>{{ 'device'|trans }}</th>
-                                <th></th>
                                 <th>{{ 'actions'|trans }}</th>
                             </tr>
                             </thead>
@@ -40,7 +39,6 @@
                                     <td><a href="#">{{ item.title | trans }}</a></td>
                                     <td>{{ item.datetime.format('d/m/Y H:i:s') }}</td>
                                     <td>{{ item.device }}</td>
-                                    <td></td>
                                     <td>
                                         {% include '_components/button-modal.html.twig' with {
                                             item: item
@@ -60,4 +58,5 @@
 {% block extra_javascripts %}
     {{ parent() }}
     <script type="module" src="{{ asset('js/modal-timeline.js') }}"></script>
+    <script src="{{ asset('js/grid-init.js') }}"></script>
 {% endblock %}

--- a/templates/_admin/user/_partials/entity-timeline.html.twig
+++ b/templates/_admin/user/_partials/entity-timeline.html.twig
@@ -1,4 +1,4 @@
-<table class="table table-hover table-striped">
+<table class="js-grid table table-hover table-striped">
     <thead class="table-dark">
     <tr>
         <th>{{ 'title'|trans }}</th>

--- a/templates/_admin/user/list.html.twig
+++ b/templates/_admin/user/list.html.twig
@@ -16,7 +16,7 @@
 
                         <hr>
 
-                        <table class="table table-hover table-striped">
+                        <table class="js-grid table table-hover table-striped">
                             <thead class="table-dark">
                             <tr>
                                 <th>{{ 'name'|trans }}</th>
@@ -62,4 +62,5 @@
 {% block extra_javascripts %}
     {{ parent() }}
     <script src="{{ asset('js/modal-photo.js') }}"></script>
+    <script src="{{ asset('js/grid-init.js') }}"></script>
 {% endblock %}

--- a/templates/_admin/user/timeline.html.twig
+++ b/templates/_admin/user/timeline.html.twig
@@ -44,4 +44,5 @@
 {% block extra_javascripts %}
     {{ parent() }}
     <script type="module" src="{{ asset('js/modal-timeline.js') }}"></script>
+    <script src="{{ asset('js/grid-init.js') }}"></script>
 {% endblock %}

--- a/templates/_layouts/base.html.twig
+++ b/templates/_layouts/base.html.twig
@@ -9,6 +9,10 @@
         <link rel="icon" href="/favicons/favicon-16x16.png">
         <link href="https://cdn.jsdelivr.net/npm/aurora-user-interface@5.3.23/dist/css/bootstrap.min.css" rel="stylesheet">
         <link href="https://cdn.jsdelivr.net/combine/npm/aurora-user-interface@5.3.23/dist/css/card.min.css,npm/aurora-user-interface@5.3.23/dist/css/colors.min.css,npm/aurora-user-interface@5.3.23/dist/css/accordion.min.css,npm/aurora-user-interface@5.3.23/dist/css/custom.min.css,npm/aurora-user-interface@5.3.23/dist/css/editor.min.css,npm/aurora-user-interface@5.3.23/dist/css/faq.min.css,npm/aurora-user-interface@5.3.23/dist/css/filter-date.min.css,npm/aurora-user-interface@5.3.23/dist/css/forms.min.css,npm/aurora-user-interface@5.3.23/dist/css/layout.min.css,npm/aurora-user-interface@5.3.23/dist/css/navigation.min.css,npm/aurora-user-interface@5.3.23/dist/css/side-filter.min.css,npm/aurora-user-interface@5.3.23/dist/css/snackbar.min.css,npm/aurora-user-interface@5.3.23/dist/css/timeline.min.css" rel="stylesheet">
+        <link
+                href="https://unpkg.com/gridjs/dist/theme/mermaid.min.css"
+                rel="stylesheet"
+        />
 
         {% block javascripts %}
             {% block importmap %}{{ importmap('app') }}{% endblock %}
@@ -21,6 +25,7 @@
         {% block body %}{% endblock %}
 
         <script src="https://cdn.jsdelivr.net/npm/aurora-user-interface@5.3.23/dist/js/bootstrap.bundle.min.js"></script>
+        <script src="https://unpkg.com/gridjs/dist/gridjs.umd.js"></script>
 
         {% block extra_javascripts %}
         {% endblock %}

--- a/templates/regmel/admin/company/details.html.twig
+++ b/templates/regmel/admin/company/details.html.twig
@@ -77,7 +77,7 @@
                             Acesse aqui o <a href="">Guia de Consulta</a>
                         </div>
 
-                        <table class="table table-hover table-striped mt-3">
+                        <table class="js-grid table table-hover table-striped mt-3">
                             <thead class="table-dark">
                             <tr>
                                 <th>Titulo</th>
@@ -159,7 +159,7 @@
                             <a href="" data-bs-toggle="modal" data-bs-target="#modalInvite" class="btn btn-outline-success btn-sm">Convidar</a>
                         {% endif %}
 
-                        <table class="table table-hover table-striped mt-3">
+                        <table class="js-grid table table-hover table-striped mt-3">
                             <thead class="table-dark">
                             <tr>
                                 <th>Nome</th>
@@ -227,4 +227,5 @@
     {{ parent() }}
     <script type="module" src="{{ asset('js/modal-timeline.js') }}"></script>
     <script type="module" src="{{ asset('js/regmel/modal-member-details.js') }}"></script>
+    <script src="{{ asset('js/grid-init.js') }}"></script>
 {% endblock %}

--- a/templates/regmel/admin/company/list.html.twig
+++ b/templates/regmel/admin/company/list.html.twig
@@ -21,7 +21,7 @@
 
                         <hr>
 
-                        <table class="table table-hover table-striped">
+                        <table class="js-grid table table-hover table-striped">
                             <thead class="table-dark">
                             <tr>
                                 <th>{{ 'name'|trans }}</th>
@@ -85,4 +85,5 @@
 
 {% block extra_javascripts %}
     {{ parent() }}
+    <script src="{{ asset('js/grid-init.js') }}"></script>
 {% endblock %}

--- a/templates/regmel/admin/company/timeline.html.twig
+++ b/templates/regmel/admin/company/timeline.html.twig
@@ -4,34 +4,32 @@
     <div class="management-content w-100">
         <div class="row">
             <div class="col-12">
-                <div class="card card-body shadow">
-                    <table class="table table-hover table-striped">
-                        <thead class="table-dark">
+                <table class="js-grid table table-hover table-striped">
+                    <thead class="table-dark">
+                    <tr>
+                        <th>{{ 'title'|trans }}</th>
+                        <th>{{ 'created_at'|trans }}</th>
+                        <th>{{ 'device'|trans }}</th>
+                        <th></th>
+                        <th>{{ 'actions'|trans }}</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for item in timeline %}
                         <tr>
-                            <th>{{ 'title'|trans }}</th>
-                            <th>{{ 'created_at'|trans }}</th>
-                            <th>{{ 'device'|trans }}</th>
-                            <th></th>
-                            <th>{{ 'actions'|trans }}</th>
+                            <td><a href="#">{{ item.title | trans }}</a></td>
+                            <td>{{ item.datetime.format('d/m/Y H:i:s') }}</td>
+                            <td>{{ item.device }}</td>
+                            <td></td>
+                            <td>
+                                {% include '_components/button-modal.html.twig' with {
+                                    item: item
+                                } %}
+                            </td>
                         </tr>
-                        </thead>
-                        <tbody>
-                        {% for item in timeline %}
-                            <tr>
-                                <td><a href="#">{{ item.title | trans }}</a></td>
-                                <td>{{ item.datetime.format('d/m/Y H:i:s') }}</td>
-                                <td>{{ item.device }}</td>
-                                <td></td>
-                                <td>
-                                    {% include '_components/button-modal.html.twig' with {
-                                        item: item
-                                    } %}
-                                </td>
-                            </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
+                    {% endfor %}
+                    </tbody>
+                </table>
             </div>
         </div>
     </div>

--- a/templates/regmel/admin/municipality/details.html.twig
+++ b/templates/regmel/admin/municipality/details.html.twig
@@ -106,7 +106,7 @@
                                 </div>
 
 
-                                <table class="table table-hover table-striped mt-3">
+                                <table class="js-grid table table-hover table-striped mt-3">
                                     <thead class="table-dark">
                                         <tr>
                                             <th>Titulo</th>
@@ -199,7 +199,7 @@
                                     <a href="" data-bs-toggle="modal" data-bs-target="#modalInvite" class="btn btn-outline-success btn-sm">Convidar</a>
                                 {% endif %}
 
-                                <table class="table table-hover table-striped mt-3">
+                                <table class="js-grid table table-hover table-striped mt-3">
                                     <thead class="table-dark">
                                     <tr>
                                         <th>Nome</th>
@@ -277,4 +277,5 @@
     {{ parent() }}
     <script type="module" src="{{ asset('js/modal-timeline.js') }}"></script>
     <script type="module" src="{{ asset('js/regmel/modal-member-details.js') }}"></script>
+    <script src="{{ asset('js/grid-init.js') }}"></script>
 {% endblock %}

--- a/templates/regmel/admin/municipality/list.html.twig
+++ b/templates/regmel/admin/municipality/list.html.twig
@@ -26,7 +26,7 @@
 
                         <hr>
 
-                        <table class="table table-hover table-striped">
+                        <table class="js-grid table table-hover table-striped">
                             <thead class="table-dark">
                             <tr>
                                 <th>{{ 'photo'|trans }}</th>
@@ -70,4 +70,5 @@
 
 {% block extra_javascripts %}
     {{ parent() }}
+    <script src="{{ asset('js/grid-init.js') }}"></script>
 {% endblock %}

--- a/templates/regmel/admin/municipality/timeline.html.twig
+++ b/templates/regmel/admin/municipality/timeline.html.twig
@@ -4,34 +4,32 @@
     <div class="management-content w-100">
         <div class="row">
             <div class="col-12">
-                <div class="card card-body shadow">
-                    <table class="table table-hover table-striped">
-                        <thead class="table-dark">
+                <table class="js-grid table table-hover table-striped">
+                    <thead class="table-dark">
+                    <tr>
+                        <th>{{ 'title'|trans }}</th>
+                        <th>{{ 'created_at'|trans }}</th>
+                        <th>{{ 'device'|trans }}</th>
+                        <th></th>
+                        <th>{{ 'actions'|trans }}</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    {% for item in timeline %}
                         <tr>
-                            <th>{{ 'title'|trans }}</th>
-                            <th>{{ 'created_at'|trans }}</th>
-                            <th>{{ 'device'|trans }}</th>
-                            <th></th>
-                            <th>{{ 'actions'|trans }}</th>
+                            <td><a href="#">{{ item.title | trans }}</a></td>
+                            <td>{{ item.datetime.format('d/m/Y H:i:s') }}</td>
+                            <td>{{ item.device }}</td>
+                            <td></td>
+                            <td>
+                                {% include '_components/button-modal.html.twig' with {
+                                    item: item
+                                } %}
+                            </td>
                         </tr>
-                        </thead>
-                        <tbody>
-                        {% for item in timeline %}
-                            <tr>
-                                <td><a href="#">{{ item.title | trans }}</a></td>
-                                <td>{{ item.datetime.format('d/m/Y H:i:s') }}</td>
-                                <td>{{ item.device }}</td>
-                                <td></td>
-                                <td>
-                                    {% include '_components/button-modal.html.twig' with {
-                                        item: item
-                                    } %}
-                                </td>
-                            </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
+                    {% endfor %}
+                    </tbody>
+                </table>
             </div>
         </div>
     </div>


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Branch?       | feature/implements-gridjs                                             |
| Bug fix?      | no                                                                                                             |
| New feature?  | yes                                                           |
| Deprecations? | no                                      |
| Issues        | Fix #136  |

### Implementação da Grid.js nas tabelas

Foi implementada a biblioteca **Grid.js** em todas as tabelas da aplicação. A escolha dessa lib se deu por não depender de jQuery, ao contrário do DataTables (sugerido na task), que ainda faz uso de jQuery. A Grid.js possui uma documentação clara e de fácil entendimento. Para adicionar novas funcionalidades às tabelas, basta consultar os exemplos em:

https://gridjs.io/docs/examples/hello-world

#### Alterar nessa parte do javascript

```js
const grid = new gridjs.Grid({
  columns: headers.map(name => ({
    name,
    formatter: cell => gridjs.html(cell)
  })),
  data: data,
  search: true,
  sort: true,
  pagination: { enabled: true, limit: 10 },
  className: {
    table: 'table table-striped table-hover'
  }
});
```

A documentação completa está disponível em:

https://gridjs.io/docs

---

### Como usar em futuras tabelas

1. **Adicione a classe** `js-grid` **na sua `<table>`**

   ```html
   <table class="js-grid table table-hover table-striped">
     …
   </table>
   ```

2. **Inclua o script de inicialização** em seu template:

   ```twig
   <script src="{{ asset('js/grid-init.js') }}"></script>
   ```

3. **Pronto!** A tabela será convertida para Grid.js automaticamente.  
   Caso queira desativar o Grid.js, basta remover a classe `js-grid`; a tabela original em HTML continuará sendo exibida.

---

> **Observação:**  
> Foi criado um módulo de inicialização Grid.js que:
> - Lê os dados da tabela já renderizada no DOM  
> - Inicializa o Grid.js com busca, ordenação e paginação  
> - Remove a tabela original em HTML  
>
> Assim, se no futuro surgir qualquer problema com o Grid.js, basta remover a classe `js-grid` e nossa tabela padrão permanecerá intacta.


https://github.com/user-attachments/assets/779d41f0-e8f3-4f17-9b63-f23bc4c4da21




