### PR TITLE
Add notice to submit documents as a single PDF in advance proposals.

### DIFF
--- a/templates/regmel/admin/proposal/_partials/forms/add-proposal-form.html.twig
+++ b/templates/regmel/admin/proposal/_partials/forms/add-proposal-form.html.twig
@@ -6,11 +6,7 @@
     <div class="accordion accordion-flush accordion-cards mt-4" id="accordionPanelsStayOpenExample">
         <div class="accordion-item">
             <h2 class="accordion-header">
-                <button class="accordion-button" type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#panelsStayOpen-collapseOne"
-                        aria-expanded="true"
-                        aria-controls="panelsStayOpen-collapseOne">
+                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#panelsStayOpen-collapseOne" aria-expanded="true" aria-controls="panelsStayOpen-collapseOne">
                     Identificação da Proposta
                 </button>
             </h2>
@@ -131,37 +127,43 @@
                                 </div>
                             </div>
 
-                        {% if company.extraFields.tipo == 'Entidade' %}
-                            <div class="mt-4 mb-2 text-primary">
-                                <strong>{{ 'proposal.need_advance'|trans }}<span class="text-danger">*</span></strong>
-                            </div>
-                            <div>
-                                <input type="radio" id="antecipacao_sim" name="anticipation" value="true" required>
-                                <label for="antecipacao_sim">{{ 'yes'|trans }}</label>
-                                <input class="ms-2" type="radio" id="antecipacao_nao" name="anticipation" value="false" required>
-                                <label for="antecipacao_nao">{{ 'no'|trans }}</label>
-                            </div>
+                            {% if company.extraFields.tipo == 'Entidade' %}
+                                <div class="mt-4 mb-2 text-primary">
+                                    <strong>{{ 'proposal.need_advance'|trans }}<span class="text-danger">*</span></strong>
+                                </div>
+                                <div>
+                                    <input type="radio" id="antecipacao_sim" name="anticipation" value="true" required>
+                                    <label for="antecipacao_sim">{{ 'yes'|trans }}</label>
+                                    <input class="ms-2" type="radio" id="antecipacao_nao" name="anticipation" value="false" required>
+                                    <label for="antecipacao_nao">{{ 'no'|trans }}</label>
+                                </div>
 
-                            <div id="campos-antecipacao" style="display:none;">
-                                <div class="mt-3">
-                                    <label class="form-label fw-bold">
-                                        {{ 'proposal.experience_field'|trans }}
-                                        <br>
-                                        <a href="/files/ANEXO IV - DECLARAÇÃO DE EXPERIENCIA.docx" download>{{ 'proposal.download_model'|trans }}</a>
-                                        <span class="text-danger">*</span>
-                                    </label>
-                                    <input type="file" name="annex_iv_c_file" data-allowed="pdf" accept="application/pdf" data-label="Anexo IV-C" class="form-control" required>
+                                <div id="campos-antecipacao" style="display:none;">
+                                    <div class="alert alert-info border border-primary shadow-sm mt-3">
+                                        <i class="material-icons align-middle text-primary me-2">info</i>
+                                        <strong>{{ 'attention' | trans }}</strong> {{ 'all_documents' | trans }}
+                                        <hr class="my-2">
+                                            {{ 'several_documents' | trans }}
+                                    </div>
+
+                                    <div class="mt-3">
+                                        <label class="form-label fw-bold">
+                                            {{ 'proposal.experience_field'|trans }}<br>
+                                            <a href="/files/exemplo-anexo-iv-c.docx" download>{{ 'proposal.download_model'|trans }}</a>
+                                            <span class="text-danger">*</span>
+                                        </label>
+                                        <input type="file" name="annex_iv_c_file" data-allowed="pdf" accept="application/pdf" id="Anexo IV-C" class="form-control" required>
+                                    </div>
+                                    <div class="mt-3">
+                                        <label class="form-label fw-bold">{{ 'proposal.responsible_field'|trans }} <span class="text-danger">*</span></label>
+                                        <input type="file" name="technical-manager_file" data-allowed="pdf" id="Responsável técnico" accept="application/pdf" class="form-control" required>
+                                    </div>
+                                    <div class="mt-3">
+                                        <label class="form-label fw-bold">{{ 'proposal.rrt_art_field'|trans }} <span class="text-danger">*</span></label>
+                                        <input type="file" name="rrt_art_file" data-allowed="pdf" accept="application/pdf" id="RRT ART" class="form-control" required>
+                                    </div>
                                 </div>
-                                <div class="mt-3">
-                                    <label class="form-label fw-bold">{{ 'proposal.responsible_field'|trans }} <span class="text-danger">*</span></label>
-                                    <input type="file" name="technical-manager_file" data-allowed="pdf" data-label="Responsável técnico" accept="application/pdf" class="form-control" required>
-                                </div>
-                                <div class="mt-3">
-                                    <label class="form-label fw-bold">{{ 'proposal.rrt_art_field'|trans }} <span class="text-danger">*</span></label>
-                                    <input type="file" name="rrt_art_file" data-allowed="pdf" accept="application/pdf" data-label="RRT ART" class="form-control" required>
-                                </div>
-                            </div>
-                        {% endif %}
+                            {% endif %}
                         </div>
 
                         <div class="col">
@@ -185,7 +187,7 @@
 
 <script>
     function atualizarValor() {
-        let value = parseInt(document.getElementById('quantity_houses').value)
+        let value = parseInt(document.getElementById('quantity_houses').value);
 
         if (true !== isNaN(value)) {
             document.getElementById('x').innerHTML = (

--- a/translations/messages.regmel.yaml
+++ b/translations/messages.regmel.yaml
@@ -53,6 +53,7 @@ all_regions: Todas as regiões
 all_states: Todos os estados
 all_types: Todos os tipos
 all_status: Todos os status
+all_documents: Todos os documentos abaixo devem ser enviados em um único arquivo PDF.
 allow_free_linking: Permitir livre vinculação com
 allowed: Com permissão
 admin_options: Opções do Administrador
@@ -82,6 +83,7 @@ apply_filter: Aplicar Filtros
 attachments_and_links: Anexos e links
 attitudinal_accessibility: Acessibilidade atitudinal
 audio_description: Áudio descrição
+attention: Atenção
 awaiting: Aguardando
 awaiting_confirmation: Aguardando Confirmar Conta
 
@@ -476,6 +478,7 @@ ROLE_SNP: Administrador SNP
 rejected: Rejeitado
 
 selection: Seleção
+several_documents: Caso existam diversos documentos, reúna todos em um único arquivo PDF antes do envio.
 
 tags: Tags
 term: Termo


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Branch?       | improv/include-notice-documents-pdf-format-proposals-advance-notice                                             |
| Bug fix?      | no                                                                                                                    |
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->                                                                   |
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->                                                  |
| Issues        | Fix #352 <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |

## COMO ESTÁ
![Gravação de tela de 2025-05-21 12-30-18](https://github.com/user-attachments/assets/65a9ceb0-8dcb-49d8-a6f3-873625b0416c)
