### PR TITLE
Hide anticipation column for municipality user

### DIFF
--- a/templates/regmel/admin/municipality/details.html.twig
+++ b/templates/regmel/admin/municipality/details.html.twig
@@ -191,7 +191,9 @@
                                             <th>Titulo</th>
                                             <th>Empresa/OSC</th>
                                             <th>Status</th>
-                                            <th>{{ 'proposal.anticipation'|trans }}</th>
+                                            {% if is_granted('ROLE_ADMIN') or is_granted('ROLE_MANAGER') %}
+                                                <th>{{ 'proposal.anticipation'|trans }}</th>
+                                            {% endif %}
                                             <th>Ações</th>
                                         </tr>
                                     </thead>
@@ -215,17 +217,19 @@
                                                     {{ status }}
                                                 </span>
                                             </td>
-                                            <td>
-                                                {% set anticipation = proposal.extraFields.anticipation ?? 'false' %}
-                                                {% set anticipationClass = ({
-                                                    'true': 'bg-primary',
-                                                    'false': 'bg-secondary',
-                                                }[anticipation] ?? 'bg-secondary') %}
+                                            {% if is_granted('ROLE_ADMIN') or is_granted('ROLE_MANAGER') %}
+                                                <td>
+                                                    {% set anticipation = proposal.extraFields.anticipation ?? 'false' %}
+                                                    {% set anticipationClass = ({
+                                                        'true': 'bg-primary',
+                                                        'false': 'bg-secondary',
+                                                    }[anticipation] ?? 'bg-secondary') %}
 
-                                                <span class="badge {{ anticipationClass }}">
-                                                    {{ anticipation == 'true' ? 'proposal.in_anticipation'|trans : 'proposal.no_anticipation'|trans }}
-                                                </span>
-                                            </td>
+                                                    <span class="badge {{ anticipationClass }}">
+                                                        {{ anticipation == 'true' ? 'proposal.in_anticipation'|trans : 'proposal.no_anticipation'|trans }}
+                                                    </span>
+                                                </td>
+                                            {% endif %}
                                             <td>
                                                 <button
                                                         class="btn btn-outline-info btn-sm"


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Branch?       | improv/hide-anticipation-to-municipality                                                |
| Bug fix?      | no                                                                                                                    |
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->                                                                   |
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->                                                  |
| Issues        | Fix #355  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |

## Como está:

![image](https://github.com/user-attachments/assets/5c44128d-4229-4aeb-9f4c-2def5685155d)

![image](https://github.com/user-attachments/assets/513e4e13-c907-4611-bf8a-3ddb6a03ae30)

