### PR TITLE
Adds button export docs anticipation recourse in proposal list page

### DIFF
--- a/cypress/regmel/e2e/web/proprosal/admin-proposal-list.cy.js
+++ b/cypress/regmel/e2e/web/proprosal/admin-proposal-list.cy.js
@@ -32,7 +32,8 @@ describe('Listagem de propostas', () => {
         cy.get(':nth-child(2) > [data-column-id="qtd.Domicílios"] > span').should('contain.text','100');
         cy.get(':nth-child(2) > [data-column-id="áreaTotal"] > span').should('contain.text','1000');
         cy.get(':nth-child(2) > [data-column-id="valorGlobalDaProposta"] > span').should('contain.text','R$ 4.500.000,00');
-        cy.get(':nth-child(2) > [data-column-id="ações"] > span > .btn').should('contain.text','Ver Proposta').click();
+        cy.get(':nth-child(2) > [data-column-id="ações"] > span > div > button').click();
+        cy.get(':nth-child(2) > [data-column-id="ações"] > span > .dropdown > .dropdown-menu > :nth-child(1) > .dropdown-item').click();
 
         cy.get('#proposalDetailsLabel').should('contain.text','Proposta - Área Teste');
 

--- a/src/Regmel/Service/ProposalService.php
+++ b/src/Regmel/Service/ProposalService.php
@@ -372,6 +372,39 @@ readonly class ProposalService extends AbstractEntityService implements Proposal
         return $zipFilePath;
     }
 
+    public function exportAnticipationFiles(array $proposals): string
+    {
+        $zipFilePath = sprintf('%s/storage/regmel/company/documents/anticipation_export.zip', $this->parameterBag->get('kernel.project_dir'));
+
+        $zip = new ZipArchive();
+
+        if (true !== $zip->open($zipFilePath, ZipArchive::CREATE | ZipArchive::OVERWRITE)) {
+            throw new UnableCreateFileException();
+        }
+
+        foreach ($proposals as $proposal) {
+            $extra = $proposal->getExtraFields();
+            $files = [
+                'annex_iv_c_file',
+                'technical-manager_file',
+                'rrt_art_file',
+            ];
+            foreach ($files as $field) {
+                if (!empty($extra[$field])) {
+                    $filePath = $this->getDocumentPath($extra[$field]);
+
+                    if (file_exists($filePath)) {
+                        $zip->addFile($filePath, $extra[$field]);
+                    }
+                }
+            }
+        }
+
+        $zip->close();
+
+        return $zipFilePath;
+    }
+
     private function getDocumentPath(string $file): string
     {
         $path = $this->parameterBag->get('kernel.project_dir');

--- a/templates/regmel/admin/municipality/documents.html.twig
+++ b/templates/regmel/admin/municipality/documents.html.twig
@@ -15,7 +15,7 @@
                         <div class="row justify-content-between">
                             <div class="col">
                                 <h2>
-                                    {{ 'organizations'|trans }} - {{ 'documents'|trans }}
+                                    {{ 'municipalities'|trans }} - {{ 'documents'|trans }}
                                 </h2>
                             </div>
 

--- a/templates/regmel/admin/proposal/list.html.twig
+++ b/templates/regmel/admin/proposal/list.html.twig
@@ -119,23 +119,56 @@
                                         {{ proposal.anticipation == 'true' ? 'proposal.in_anticipation'|trans : 'proposal.no_anticipation'|trans }}
                                     </span>
                                 </td>
-                                <td>
-                                    <button
-                                        class="btn btn-outline-info btn-sm"
-                                        data-proposal="{{ proposal|json_encode }}"
-                                        onClick="modalProposalDetails(this)"
-                                    >
-                                        Ver Proposta
-                                    </button>
-                                    {% if proposal.status != 'Recebida' and  proposal.status != 'Sem Adesão do Município' %}
-                                        <a  onclick="openProposalStatusModal('{{ proposal.id }}')"
-                                            data-bs-toggle="modal"
-                                            data-bs-target="#modalProposalStatus"
-                                            href="#"
-                                            class="btn btn-outline-success btn-sm">
-                                            Status
-                                        </a>
-                                    {% endif %}
+                                <td style="position: relative;">
+                                    <div class="dropdown">
+                                        <button
+                                                class="btn btn-outline-warning btn-sm dropdown-toggle"
+                                                type="button"
+                                                id="dropdownMenu{{ proposal.id }}"
+                                                data-bs-toggle="dropdown"
+                                                aria-expanded="false"
+                                                style="--bs-dropdown-min-width: 0; width: auto;"
+                                        >
+                                            {{ 'actions'|trans }}
+                                        </button>
+                                        <ul
+                                                class="dropdown-menu dropdown-menu-end"
+                                                aria-labelledby="dropdownMenu{{ proposal.id }}"
+                                                style="--bs-dropdown-min-width: 0; width: auto;"
+                                        >
+                                            <li>
+                                                <a
+                                                        href="#"
+                                                        class="dropdown-item"
+                                                        onclick="modalProposalDetails(this)"
+                                                        data-proposal="{{ proposal|json_encode }}"
+                                                >
+                                                    Ver Proposta
+                                                </a>
+                                            </li>
+                                            <li>
+                                                <a
+                                                        href="#"
+                                                        class="dropdown-item"
+                                                        onclick="openProposalStatusModal('{{ proposal.id }}')"
+                                                        data-bs-toggle="modal"
+                                                        data-bs-target="#modalProposalStatus"
+                                                >
+                                                    Atualizar Status
+                                                </a>
+                                            </li>
+                                            {% if proposal.anticipation == 'true' %}
+                                                <li>
+                                                    <a
+                                                            href="{{ path('admin_regmel_proposal_anticipation_files_download', {'id': proposal.id}) }}"
+                                                            class="dropdown-item"
+                                                    >
+                                                        Baixar documentos de antecipação
+                                                    </a>
+                                                </li>
+                                            {% endif %}
+                                        </ul>
+                                    </div>
                                 </td>
                             </tr>
                         {% else %}

--- a/translations/messages.regmel.yaml
+++ b/translations/messages.regmel.yaml
@@ -315,6 +315,7 @@ message: Mensagem
 months: meses
 most_recent: Mais Recente
 municipality: Município
+municipalities: Municípios
 municipality_found: Município não encontrado
 municipality_created: Município criado com sucesso. Veja no seu email o link para confirmar sua conta.
 my_account: Minha Conta


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Branch?       | feat/button-export-docs-anticipation                                              |
| Bug fix?      | no                                                                                                                    |
| New feature?  | yes <!-- please update src/**/CHANGELOG.md files -->                                                                   |
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->                                                  |
| Issues        | Fix #368  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |

![image](https://github.com/user-attachments/assets/34023f12-4eed-4d30-9f90-30b53ae32779)


![image](https://github.com/user-attachments/assets/5cf5a75e-d894-4cb4-9981-8b6161ce6b28)


![Peek 22-05-2025 22-23](https://github.com/user-attachments/assets/6f2f3b05-e034-4b57-a351-7fcf0ff67fbb)
