### PR TITLE
Show HTML error pages instead of JSON for web requests.

### DIFF
--- a/templates/error-general/error-general.html.twig
+++ b/templates/error-general/error-general.html.twig
@@ -1,0 +1,25 @@
+{% extends "_layouts/blank-not-logged.html.twig" %}
+
+{% block title %}
+    {{ 'view.error_general.title' | trans }}
+{% endblock %}
+
+{% block stylesheets %}
+    {{ parent() }}
+    <link rel="stylesheet" href="{{ asset('styles/pages/not-found.css') }}">
+{% endblock %}
+
+{% block content %}
+    <div class="body-not-found">
+        <div class="error-container">
+            <div class="error-text">
+                <h1>{{ 'view.error_general.title' | trans }}</h1>
+                <h2>{{ 'view.error_general.subtitle' | trans }}</h2>
+                <p>{{ 'view.error_general.text_first' | trans }}</p>
+                <p>{{ 'view.error_general.text_second' | trans }}</p>
+                <a href="{{ path('admin_dashboard') }}" class="btn btn-primary">{{ 'view.error_general.dashboard' | trans }}</a>
+            </div>
+            <img src="{{ asset('img/error.png') }}" alt="{{ 'view.error_general.image' | trans }}">
+        </div>
+    </div>
+{% endblock %}

--- a/templates/forbidden/forbidden.html.twig
+++ b/templates/forbidden/forbidden.html.twig
@@ -1,0 +1,25 @@
+{% extends "_layouts/blank-not-logged.html.twig" %}
+
+{% block title %}
+    {{ 'view.forbidden.title' | trans }}
+{% endblock %}
+
+{% block stylesheets %}
+    {{ parent() }}
+    <link rel="stylesheet" href="{{ asset('styles/pages/not-found.css') }}">
+{% endblock %}
+
+{% block content %}
+    <div class="body-not-found">
+        <div class="error-container">
+            <div class="error-text">
+                <h1>{{ 'view.forbidden.error-403' | trans }}</h1>
+                <h2>{{ 'view.forbidden.error-title' | trans }}</h2>
+                <p>{{ 'view.forbidden.error-text_first' | trans }}</p>
+                <p>{{ 'view.forbidden.error-text_second' | trans }}</p>
+                <a href="{{ path('admin_dashboard') }}" class="btn btn-primary">{{ 'view.forbidden.error-dashboard' | trans }}</a>
+            </div>
+            <img src="{{ asset('img/error.png') }}" alt="{{ 'view.forbidden.error-image' | trans }}">
+        </div>
+    </div>
+{% endblock %}

--- a/templates/not-found/not-found.html.twig
+++ b/templates/not-found/not-found.html.twig
@@ -1,7 +1,7 @@
 {% extends "_layouts/blank-not-logged.html.twig" %}
 
 {% block title %}
-    {{ 'view.not-found.error-404' | trans }}
+    {{ 'view.not-found.title' | trans }}
 {% endblock %}
 
 {% block stylesheets %}

--- a/translations/messages.regmel.yaml
+++ b/translations/messages.regmel.yaml
@@ -1106,12 +1106,30 @@ view:
       deleted: A Acessibilidade Arquitetônica foi excluída
 
   not-found:
+    title: Página não encontrada
     error-404: Error 404
     error-text_first: Ops, página não encontrada.
     error-text_second: Essa página não existe mais ou mudou de endereço.
     error-text_third: Mas não se preocupe, existem muitas outras páginas para conhecer aqui na Plataforma Minha Casa Melhor.
     error-homepage: Voltar para a página inicial
     error-image: Imagem de dúvida
+
+  forbidden:
+    title: Acesso Negado
+    error-403: Erro 403
+    error-title: Ops, acesso negado.
+    error-text_first: Você não tem permissão para acessar esta página ou o conteúdo está restrito.
+    error-text_second: Mas não se preocupe, você pode explorar outras áreas da Plataforma Minha Casa Melhor.
+    error-dashboard: Voltar para o painel de controle
+    error-image: Erro 403
+
+  error_general:
+    title: Ocorreu um erro
+    subtitle: Algo inesperado aconteceu.
+    text_first: Não conseguimos processar sua solicitação agora.
+    text_second: Mas não se preocupe, você pode tentar novamente mais tarde ou navegar por outras páginas da Plataforma Minha Casa Melhor.
+    dashboard: Voltar para o painel de controle
+    image: Erro
 
   phase:
     out_of_period: Fora do prazo de inscrição


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Branch?       | hotfix/json-errors-in-web                                                |
| Bug fix?      | no                                                                                                                    |
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->                                                                   |
| Deprecations? | no <!-- please update UPGRADE-*.md and src/**/CHANGELOG.md files -->                                                  |
| Issues        | Fix #375  <!-- prefix each issue number with "Fix #", no need to create an issue if none exists, explain below instead --> |

erros genericos: 

![image](https://github.com/user-attachments/assets/006212d9-2e16-4e26-8b86-3be40b12f26e)


erros 403: 

![image](https://github.com/user-attachments/assets/b12d7009-5d79-480c-93e3-bcd1f7a94b68)
