### PR TITLE
Create script to register cities

### DIFF
--- a/cypress/scripts/01-extract-states-cities.cy.js
+++ b/cypress/scripts/01-extract-states-cities.cy.js
@@ -1,0 +1,32 @@
+describe('Extrai lista de estados e cidades via API e grava em fixture', () => {
+    it('Deve obter todos os estados e suas cidades e salvar em cypress/fixtures/statesCities.json', () => {
+        cy.request({
+            method: 'GET',
+            url: '/api/states',
+            failOnStatusCode: true
+        }).then(responseStates => {
+            expect(responseStates.status).to.equal(200);
+            const listStates = responseStates.body;
+            const statesCities = {}
+            
+            cy.wrap(listStates).each(estadoObj => {
+                const name = estadoObj.name;
+                const stateId = estadoObj.id;
+
+                cy.request({
+                    method: 'GET',
+                    url: `/api/states/${stateId}/cities`,
+                    failOnStatusCode: true
+                }).then(responseCities => {
+                    expect(responseCities.status).to.equal(200);
+                    const citiesName = responseCities.body.map(ci => ci.name);
+                    statesCities[name] = citiesName;
+                });
+            })
+                .then(() => {
+                    cy.writeFile('cypress/fixtures/statesCities.json', statesCities, { spaces: 2 });
+                    cy.log('Fixture "statesCities.json" criada com sucesso');
+                });
+        });
+    });
+});

--- a/cypress/scripts/02-register-cities.cy.js
+++ b/cypress/scripts/02-register-cities.cy.js
@@ -1,0 +1,83 @@
+import stateCities from '../fixtures/statesCities.json';
+
+describe('Cadastro dinâmico de Municípios', () => {
+    const maxCities = 300;
+    const maxPerState = 20;
+    const register = [];
+    let globalCounter = 0;
+
+    Object.entries(stateCities).forEach(([stateName, citiesArray]) => {
+        if (globalCounter >= maxCities) return;
+
+        const limitCities = citiesArray.slice(0, maxPerState);
+        limitCities.forEach(cityName => {
+            if (globalCounter < maxCities) {
+                register.push({ state: stateName, city: cityName });
+                globalCounter += 1;
+            }
+        });
+    });
+
+    before(() => {
+        cy.log(`Total de registro que serão cadastrados: ${register.length}`);
+    });
+
+    register.forEach(({ state, city }, index) => {
+        it(`Cadastro ${index + 1}/${register.length}: ${city} (${state})`, () => {
+            const timestamp = Date.now();
+            const rawName = city
+                .normalize('NFD')
+                .replace(/[\u0300-\u036f]/g, '')
+                .replace(/\s+/g, '')
+                .toLowerCase();
+            const randomEmail = `pref.${rawName}${timestamp}@teste.com`;
+            const citySite = `https://www.${rawName}.ce.gov.br`;
+
+            cy.visit('/cadastro/municipio');
+
+            cy.get('input[name="firstname"]').type('Gestor');
+            cy.get('input[name="lastname"]').type(city);
+            cy.get('input[name="position"]').type('Prefeito(a)');
+            cy.gerarCPF().then(cpfGerado => {
+                cy.get('input[name="cpf"]').type(cpfGerado);
+            });
+            cy.get('input[name="userEmail"]').type(randomEmail);
+            cy.get('input[name="password"]').type('Aurora@2024');
+            cy.get('input[name="confirm_password"]').type('Aurora@2024');
+
+            cy.get('#state + .ts-wrapper').click();
+            cy.get('.ts-dropdown.single:visible')
+                .should('exist')
+                .find('.option')
+                .contains(new RegExp(`^${state}$`, 'i'))
+                .click();
+            cy.wait(200);
+
+            cy.get('#city + .ts-wrapper').click();
+            cy.wait(500);
+            cy.get('body').then($body => {
+                if (!$body.find('.ts-dropdown.single:visible').length) {
+                    cy.get('#city + .ts-wrapper').click();
+                }
+            });
+            cy.get('.ts-dropdown.single:visible')
+                .should('exist')
+                .find('.option')
+                .contains(new RegExp(`^${city}$`, 'i'))
+                .click();
+
+            cy.get('input[name="site"]').type(citySite);
+            cy.get('input[name="phone"]').type('85912345678');
+            cy.get('input[name="email"]').type(randomEmail);
+            cy.get('input[name="hasHousingExperience"][value="true"]').check({ force: true });
+            cy.get('input[name="hasPlhis"][value="false"]').check({ force: true });
+            cy.get('input[type="file"]').selectFile('./cypress/regmel/fixtures/file.pdf');
+            cy.get('input[name="acceptTerms"]').check({ force: true });
+            cy.get('input[name="acceptPrivacy"]').check({ force: true });
+            cy.get('input[name="acceptImage"]').check({ force: true });
+            cy.get('button[type="submit"]').click();
+            cy.wait(500);
+            cy.get('form > :nth-child(2)').should('not.exist')
+        });
+    });
+});


### PR DESCRIPTION
| Q             | A                                                                                                                         |
|---------------|---------------------------------------------------------------------------------------------------------------------------|
| Branch?       | feature/create-script-register-cities                                               |
| Bug fix?      |no                                                                                                                  |
| New feature?  |yes                     |
| Deprecations? | no                                          |
| Issues        | Fix #391  |


**Documentação: Cadastro Dinâmico de Cidades via Cypress**

Este PR implementa dois scripts Cypress para cadastrar cidades de forma dinâmica, utilizando nossa API de Estados/Cidades e um workflow em duas etapas. Abaixo está o passo a passo para configurar e executar os testes.

---

## 1. Estrutura de pastas

1. Copie a pasta `scripts` (onde estão os specs) para dentro de `cypress/e2e/`. A estrutura final deve ficar assim:

```
cypress/
  ├─ e2e/
  │    └─ scripts/
  │         ├─ 01-extract-states-cities.cy.js
  │         └─ 02-register-cities.cy.js
  ├─ fixtures/
  └─ ... (demais pastas do Cypress)
```

> **Obs.:** A pasta `fixtures` será utilizada para armazenar o JSON de estados e cidades, gerado pelo primeiro script.

---

## 2. Passo a passo de execução

### 2.1. Gerar o fixture com Estados e Cidades

1. Abra o Cypress (`npx cypress open`).

2. Execute o spec `01-extract-states-cities.cy.js`:

   * Esse arquivo faz chamadas `GET /api/states` e, para cada estado, `GET /api/states/{stateId}/cities`.
   * Ao final, ele gera (ou atualiza) o arquivo `cypress/fixtures/statesCities.json` contendo um objeto no formato:

     ```json
     {
       "Acre": ["Rio Branco", "Cruzeiro do Sul", ...],
       "Alagoas": ["Maceió", "Arapiraca", ...],
       ...
     }
     ```

3. Verifique que `cypress/fixtures/statesCities.json` foi criado e contém todos os estados e suas cidades.


### 2.2. Ajuste de quantidade de cidades

* Caso queira alterar a quantidade máxima de cidades a serem cadastradas por estado ou o total de cadastros, edite o arquivo `02-register-cities.cy.js` e ajuste as constantes:

  ```js
  const maxCities  = 300;  // Total máximo de cadastros (somatório)
  const maxPerState = 20;   // Máximo de cidades de cada estado
  ```

* Por exemplo, para cadastrar até 10 cidades por estado e 100 no total, modifique para:

  ```js
  const maxCities = 100;
  const maxPerState = 10;
  ```

### 2.3. Executar o cadastro de cidades

1. Com o JSON gerado em `cypress/fixtures/statesCities.json`, execute o spec `02-register-cities.cy.js`:

   * Esse arquivo importa o fixture, monta um array de pares `{ state, city }`, respeitando `maxPerState` e `maxCities`.
   * Para cada par, gera um `it()` que abre a página de cadastro, preenche campos e submete o formulário.

2. No Cypress GUI, clique em `02-register-cities.cy.js` para iniciar os cadastros em sequência.

3. Ao final, todos os municípios configurados serão registrados de forma automática.

> **Observação:** se sua máquina for mais lenta ou você quiser reduzir o consumo de memória, execute somente no terminal (sem IDE) com os comandos:
>
> ```bash
> make demo-regmel
> npx cypress open
> ```
>
> Em seguida, selecione e execute os specs conforme descrito acima.

---

## 3. Exemplo de comandos finais para ambiente sem IDE

Caso você prefira rodar tudo via terminal, sem abrir a IDE do Cypress:
> Lembre-se de copiar a pasta scripts para dentro da pasta e2e

1. Gere o fixture:

   ```bash
   npx cypress run --spec "cypress/e2e/scripts/01-extract-states-cities.cy.js"
   ```
2. Execute os cadastros:

   ```bash
   npx cypress run --spec "cypress/e2e/scripts/02-register-cities.cy.js"
   ```
